### PR TITLE
ビルドが通るように修正

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-ThisBuild / scalaVersion     := "2.12.8"
+ThisBuild / scalaVersion     := "2.13.8"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.example"
 ThisBuild / organizationName := "example"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.12"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.7.1

--- a/src/test/scala/example/HelloSpec.scala
+++ b/src/test/scala/example/HelloSpec.scala
@@ -1,8 +1,9 @@
 package example
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
 
-class HelloSpec extends FlatSpec with Matchers {
+class HelloSpec extends AnyFlatSpec with should.Matchers {
   "The Hello object" should "say hello" in {
     Hello.greeting shouldEqual "hello"
   }


### PR DESCRIPTION
ビルドが通らなかったから直そうとしたら、なんか色々ハマった。
ScalaTestのマイナーバージョンを上げただけで互換性がなくなってたり。。。

https://github.com/massakai/programming_in_scala/runs/7596308910?check_suite_focus=true
```
[error] java.io.IOError: java.lang.RuntimeException: /packages cannot be represented as URI
```

